### PR TITLE
Add date dependency

### DIFF
--- a/tests/testdate.phpt
+++ b/tests/testdate.phpt
@@ -2,6 +2,12 @@
 testdate.phpt: Unit tests for 'Validate.php'
 --INI--
 date.timezone=UTC
+--SKIPIF--
+<?php
+if (!@include 'Date/Calc.php') {
+  echo 'skip Requires PEAR::Date';
+}
+?>
 --FILE--
 <?php
 // $Id$


### PR DESCRIPTION
This test would fail if the PEAR Date library was missing; this adds a skip condition.